### PR TITLE
feat: automatically keep context in handlers

### DIFF
--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,20 +1,21 @@
 import * as api from "@opentelemetry/api"
- import type { H3Event } from "h3";
+import type { H3Event } from "h3";
 import { ATTR_URL_PATH, ATTR_URL_FULL, ATTR_HTTP_REQUEST_METHOD, ATTR_HTTP_RESPONSE_STATUS_CODE, ATTR_URL_SCHEME, ATTR_SERVER_ADDRESS, ATTR_SERVER_PORT } from "@opentelemetry/semantic-conventions"
 import type { NitroAppPlugin, NitroRuntimeHooks } from "nitropack";
 import { getResponseStatus, getRequestProtocol, getRequestURL, getHeaders } from "h3"
 
-const context = api.context, trace = api.trace 
+const context = api.context, trace = api.trace
 export default <NitroAppPlugin>((nitro) => {
-    nitro.hooks.hook('request', async (event) => {
+    const handler = nitro.h3App.handler
+    nitro.h3App.handler = async (event) => {
         const tracer = trace.getTracer('nitro-opentelemetry')
         const requestURL = getRequestURL(event)
-        const currentContext = context.active() 
+        const currentContext = context.active()
 
         // Extract the parent context from the headers if it exists
         // If a span is already set in the context, use it as the parent
         const parentCtx = trace.getSpan(currentContext) ? currentContext : api.propagation.extract(currentContext, getHeaders(event));
-         const span = tracer.startSpan(await getSpanName(event), {
+        const span = tracer.startSpan(await getSpanName(event), {
             attributes: {
                 [ATTR_URL_PATH]: (await nitro.h3App.resolve(event.path))?.route || event.path,
                 [ATTR_URL_FULL]: event.path,
@@ -25,13 +26,14 @@ export default <NitroAppPlugin>((nitro) => {
             },
             kind: api.SpanKind.SERVER
         }, parentCtx)
-        const ctx =  trace.setSpan(context.active(), span) 
+        const ctx = trace.setSpan(context.active(), span)
         event.otel = {
             span,
             __endTime: undefined
-            ,ctx
-        } 
-    })
+            , ctx
+        }
+        return context.with(ctx, handler, undefined, event)
+    }
 
     nitro.hooks.hook('beforeResponse', (event) => {
         event.otel.__endTime = Date.now()
@@ -40,7 +42,7 @@ export default <NitroAppPlugin>((nitro) => {
     nitro.hooks.hook('afterResponse', async (event) => {
         event.otel.span.setAttribute(ATTR_HTTP_RESPONSE_STATUS_CODE, getResponseStatus(event))
         await nitro.hooks.callHook('otel:span:end', { event, span: event.otel.span })
-        event.otel.span.end(event.otel.__endTime) 
+        event.otel.span.end(event.otel.__endTime)
     })
 
     nitro.hooks.hook('error', async (error, { event }) => {

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,10 +1,8 @@
-import * as api from "@opentelemetry/api" 
 import { defineEventHandler } from "h3";
 
-const context = api.context
-
+/**
+ * @deprecated since 0.7.1. Use `defineEventHandler` instead.
+ */
 export function defineTracedEventHandler(handler: ReturnType<typeof defineEventHandler>) { 
-    return defineEventHandler((event) => { 
-       return  context.with(event.otel.ctx, handler, undefined,  event) 
-    })
+    return defineEventHandler(handler)
 }

--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler } from "h3";
 
 /**
- * @deprecated since 0.7.1. Use `defineEventHandler` instead.
+ * @deprecated since 0.7.1. Context is automatically kept within handlers. You can use `defineEventHandler` instead.
  */
 export function defineTracedEventHandler(handler: ReturnType<typeof defineEventHandler>) { 
     return defineEventHandler(handler)


### PR DESCRIPTION
This PR removes the necessity to use `defineTracedEventHandler` to keep the context within event handler. 