### PR TITLE
fix: defineTracedEventHandler typing which was losing handler typings

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -1,10 +1,14 @@
+import type { EventHandlerRequest, EventHandlerResponse, EventHandler } from "h3";
 import * as api from "@opentelemetry/api" 
 import { defineEventHandler } from "h3";
 
 const context = api.context
 
-export function defineTracedEventHandler(handler: ReturnType<typeof defineEventHandler>) { 
-    return defineEventHandler((event) => { 
-       return  context.with(event.otel.ctx, handler, undefined,  event) 
-    })
+export function defineTracedEventHandler<
+  Request extends EventHandlerRequest = EventHandlerRequest,
+  Response = EventHandlerResponse,
+>(handler: EventHandler<Request, Response>) {
+  return defineEventHandler<Request, Response>((event) => {
+    return context.with(event.otel.ctx, handler, undefined,  event) 
+  })
 }


### PR DESCRIPTION
When upgrading to the latest version of this package, I have to wrap all my server endpoints in defineTracedHandler. This function was not keeping the type of the original handler, losing the strong-typing in the frontend part as well.

This PR aims to fix it by adding generic typing.