### PR TITLE
fix: supress 'this' in otel files

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -93,6 +93,7 @@ async function module(nitro: Nitro) {
         extensions: ['.mjs', '.ts']
     }))
 
+    // explicitly mark this as undefined for rollup to stop logging warnings about it
     nitro.hooks.hook('rollup:before', (_, rollupConfig) => {
         const ogModuleCtx = rollupConfig.moduleContext
         rollupConfig.moduleContext = (_id) => {

--- a/src/module.ts
+++ b/src/module.ts
@@ -92,6 +92,17 @@ async function module(nitro: Nitro) {
     nitro.options.plugins.push(await resolvePath('nitro-opentelemetry/runtime/plugin', {
         extensions: ['.mjs', '.ts']
     }))
+
+    nitro.hooks.hook('rollup:before', (_, rollupConfig) => {
+        const ogModuleCtx = rollupConfig.moduleContext
+        rollupConfig.moduleContext = (_id) => {
+            const id = normalize(_id)
+            if(id.includes('node_modules/@opentelemetry/api')) {
+                return '(undefined)'
+            }
+            return typeof ogModuleCtx === 'object' ? ogModuleCtx[id] : ogModuleCtx?.(id)
+        }
+    })
 }
 
 // Dual compatibility with Nuxt and Nitro Modules


### PR DESCRIPTION
an example of code taht you can find in OTEL js

````ts
var __read = (this && this.__read) || function (o, n) {
    var m = typeof Symbol === "function" && o[Symbol.iterator];
    if (!m) return o;
    var i = m.call(o), r, ar = [], e;
    try {
        while ((n === void 0 || n-- > 0) && !(r = i.next()).done) ar.push(r.value);
    }
    catch (error) { e = { error: error }; }
    finally {
        try {
            if (r && !r.done && (m = i["return"])) m.call(i);
        }
        finally { if (e) throw e.error; }
    }
    return ar;
};
````

this PR makes `this` explicitly undefined in rollup to suppress  warnings about `this` being undefined in esm from rollup