### PR TITLE
fix: throw if defineTracedEventHandler does not receive expected arguments

### DIFF
--- a/src/runtime/utils.ts
+++ b/src/runtime/utils.ts
@@ -26,6 +26,7 @@ export function defineTracedEventHandler<
       },
     })
   }
+  throw new Error("Event handler must satisfy either EventHandler or EventHandlerObject from h3")
 }
 
 function isEventHandler<


### PR DESCRIPTION
Mostly to avoid `defineTracedEventHandler` returning an `undefined` type. This PR makes `defineTracedEventHandler` throw if the arguument is not the one expected