### PR TITLE
fix: remove leftover debug log from error handler injection

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -107,10 +107,6 @@ async function module(nitro: Nitro) {
                 ;(rollupConfig.plugins as Plugin[]).push({
                     name: 'nitro-otel:inject-error-handlers',
                     async transform(code, id) {
-                        if(id.includes('prod')) {
-                            console.log(id, errorHandlers.includes(normalize(id)), errorHandlers)
-
-                        }
                         if (errorHandlers.includes(normalize(id))) {
                             const s = new MagicString(code)
                             s.prepend(`import { context } from "@opentelemetry/api";\n`)


### PR DESCRIPTION
The `nitro-otel:inject-error-handlers` rollup plugin added in #28 left a debug `console.log` behind, gated on `id.includes('prod')`. It fires during every production build — in a Nuxt 4 / Nitro 2.10+ project it matches nitropack's `runtime/internal/error/prod.mjs` and prints the module path, a boolean, and the resolved error-handler array into the
build output:

    /path/to/node_modules/.pnpm/nitropack@2.13.4.../dist/runtime/internal/error/prod.mjs true [ '/path/to/...' ]

It also matches any module whose absolute path happens to contain "prod" (e.g. a checkout under `/home/prod/`), logging once per module.

This removes the leftover block; no behavior change otherwise.
